### PR TITLE
Add accelerometer mount matrix for Linx 12X64

### DIFF
--- a/hwdb/60-sensor.hwdb
+++ b/hwdb/60-sensor.hwdb
@@ -281,6 +281,10 @@ sensor:modalias:acpi:*BOSC0200*:dmi:*:svnLENOVO*:pn80XE:*
 sensor:modalias:acpi:BOSC0200*:dmi:*:svnLINX*:pnLINX1010B:*
  ACCEL_MOUNT_MATRIX=-1, 0, 0; 0, 1, 0; 0, 0, -1
 
+# Linx 12X64
+sensor:modalias:acpi:KIOX000A*:dmi:*:svnLINX*:pnLINX12X64:*                                            
+ ACCEL_MOUNT_MATRIX=0, 1, 0; 1, 0, 0; 0, 0, 1
+
 #########################################
 # MSI
 #########################################


### PR DESCRIPTION
An accelerometer mount matrix for the LINX 12X64 tablet. Tested on my own hardware running Fedora 28 so sample size is 1 and figured out by trial and error but certainly works for me (in correcting the 'out by 90 degs' rotation from the default). Hope this can be useful for someone else.